### PR TITLE
15: Support writing facts.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2016/07/07|15   |Support writing factsyaml, include filemgr agent                                                         |
 |2016/07/06|11   |Support collectives                                                                                      |
-|2016/06/29|4    |Remove hard coded paths and move them to Hiera                                                           |
 |2016/06/30|7    |Support auditlogs                                                                                        |
-|2016/06/30|1    |Support actionpolicy                                                                                     |
 |2016/06/30|2    |Support Windows                                                                                          |
-|2016/06/30|4    |Remove some hard coded paths and move to Hiera                                                           |
+|2016/06/30|1    |Support actionpolicy                                                                                     |
+|2016/06/29|4    |Remove hard coded paths and move them to Hiera                                                           |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This is an module to manage an already installed Puppet AIO based mcollective:
   * [Puppet Agent](https://github.com/puppetlabs/mcollective-puppet-agent)
   * [Package Agent](https://github.com/puppetlabs/mcollective-package-agent)
   * [Service Agent](https://github.com/puppetlabs/mcollective-service-agent)
+  * [File Manager Agent](https://github.com/puppetlabs/mcollective-filemgr-agent)
   * [Puppet Based Security System](https://github.com/ripienaar/mcollective-security-puppet) with default secure settings
   * [Action Policy Authorization](https://github.com/puppetlabs/mcollective-actionpolicy-auth) with default secure settings
   * Audit logs in `/var/log/mcollective-audit.log` and `C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log`
+  * Facts using a YAML file refreshed using Cron or Windows Scheduler
 
 It's part of a larger effort to make bootstrapping trivial, so this is effectively a
 distribution of MCollective that pulls together various MCollective plugins to yield
@@ -82,6 +84,18 @@ mcollective::plugin_classes:
 Or you can just install them however you prefer.
 
 If for any reason you do not want some plugin on a tier, add it to the list `mcollective::plugin_classes_exclude`
+
+Facts
+-----
+
+The only supported fact source is YAML and it will refresh on every Puppet run and by default
+from Cron and Windows Scheduler.
+
+Set `mcollective::facts_refresh_interval` to `0` to disable the scheduled updates.  At present
+the output path cannot be changed and by default it will configure the daemon to the same path.
+
+You can adjust the path to include additional YAML files if you wish by updating it to consider
+multiple YAML files by specifying a `File::PATH_SEPARATOR` seperated list of paths.
 
 Authorization
 -------------

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,19 +12,23 @@ mcollective::server_config:
   rpcauthorization: 1
   rpcauthprovider: "action_policy"
   rpcaudit: 1
-  rpcauditprovider: logfile
+  rpcauditprovider: "logfile"
   plugin.rpcaudit.logfile: "/var/log/mcollective-audit.log"
+  factsource: "yaml"
+  plugin.yaml: "/etc/puppetlabs/mcollective/facts.yaml"
 
 mcollective::plugin_classes:
   - "mcollective::packager"
   - "mcollective_agent_puppet"
   - "mcollective_agent_service"
   - "mcollective_agent_package"
+  - "mcollective_agent_filemgr"
   - "mcollective_security_puppet"
   - "mcollective_util_actionpolicy"
 
 mcollective::server: true
 mcollective::client: false
+mcollective::facts_refresh_interval: 10
 mcollective::service_name: "mcollective"
 mcollective::service_ensure: "running"
 mcollective::service_enable: true
@@ -33,6 +37,7 @@ mcollective::plugin_group: "root"
 mcollective::plugin_mode: "0664"
 mcollective::libdir: "/opt/puppetlabs/mcollective/plugins/mcollective"
 mcollective::configdir: "/etc/puppetlabs/mcollective"
+mcollective::rubypath: "/opt/puppetlabs/puppet/bin/ruby"
 mcollective::plugintypes:
   - "agent"
   - "aggregate"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -4,6 +4,8 @@ mcollective::plugin_mode: ~
 
 mcollective::libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
 mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
+mcoollective::rubypath: "C:/ProgramData/PuppetLabs/puppet/bin/ruby.exe"
 
 mcollective::server_config:
   plugin.rpcaudit.logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log"
+  plugin.yaml: "C:/ProgramData/PuppetLabs/mcollective/etc/facts.yaml"

--- a/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
+++ b/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
@@ -6,7 +6,7 @@
   "summary": "<%= @plugin.metadata[:description] %>",
   "source": "<%= @plugin.metadata[:url] %>",
   "dependencies": [
-    {"name": "ripienaar/mcollective", "version_requirement": ">= 0.0.6 < 2.0.0"}
+    {"name": "ripienaar/mcollective", "version_requirement": ">= 0.0.7 < 2.0.0"}
   ],
   "requirements": [
     {

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -1,0 +1,50 @@
+class mcollective::facts (
+  String $libdir = $mcollective::libdir,
+  String $rubypath = $mcollective::rubypath,
+  String $configdir = $mcollective::configdir,
+  String $factspath = $mcollective::factspath,
+  Integer $refresh_interval = $mcollective::refresh_interval,
+  String $owner = $mcollective::plugin_owner,
+  String $group = $mcollective::plugin_group,
+  Boolean $server = $mcollective::server
+) {
+  $scriptpath = "${libdir}/refresh_facts.rb"
+
+  file{$scriptpath:
+    owner   => $owner,
+    group   => $group,
+    mode    => "0755",
+    content => template("mcollective/refresh_facts.erb"),
+  }
+
+  if $server {
+    exec{"mcollective_facts_yaml_refresh":
+      command => "${scriptpath} -o ${factspath}",
+    }
+  }
+
+  if $refresh_interval > 0 and $server {
+    $cron_ensure = "present"
+  } else {
+    $cron_ensure = "absent"
+  }
+
+  if $facts["os"]["family"] == "windows" {
+    scheduled_task{"mcollective_facts_yaml_refresh":
+      ensure               => $cron_ensure,
+      command              => $scriptpath,
+      arguments            => "-o ${factspath}",
+      trigger              => {
+        "schedule"         => "daily",
+        "start_time"       => "00:00",
+        "minutes_interval" => $refresh_interval
+      }
+    }
+  } else {
+    cron{"mcollective_facts_yaml_refresh":
+      ensure  => $cron_ensure,
+      command => "${scriptpath} -o ${factspath}",
+      minute  => "*/${refresh_interval}"
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@
 # @param common_config A hash of config items to set in both client.cfg and server.cfg
 # @param libdir The directory where plugins will go in
 # @param configdir Root directory to config files
+# @param facts_refresh_interval Minutes between fact refreshes, set to 0 to disable cron based refreshes
+# @param rubypath Path to the ruby executable
 # @param collectives A list of collectives the node belongs to
 # @param main_collective The main collective to use, last in the list of `$collectives` by default
 # @param plugin_owner The default user who will own plugin files
@@ -29,6 +31,8 @@ class mcollective (
   Hash $common_config = {},
   String $libdir,
   String $configdir,
+  String $rubypath,
+  Integer $facts_refresh_interval,
   Array[Mcollective::Collective] $collectives,
   Optional[Mcollective::Collective] $main_collective = undef,
   Optional[String] $plugin_owner,
@@ -42,8 +46,11 @@ class mcollective (
   Boolean $client,
   Boolean $server
 ) {
+  $factspath = "${configdir}/facts.yaml"
+
   include mcollective::plugin_dirs
   include mcollective::config
+  include mcollective::facts
   include mcollective::service
 
   include $plugin_classes - $plugin_classes_exclude

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ripienaar-mcollective",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "R.I.Pienaar <rip@devco.net>",
   "license": "Apache-2.0",
   "summary": "Configure the Puppet AIO MCollective",
@@ -13,6 +13,7 @@
     { "name": "ripienaar/mcollective_agent_puppet", "version_requirement": ">= 1.11.0" },
     { "name": "ripienaar/mcollective_agent_package", "version_requirement": ">= 4.4.0" },
     { "name": "ripienaar/mcollective_agent_service", "version_requirement": ">= 3.1.3" },
+    { "name": "ripienaar/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
     { "name": "ripienaar/mcollective_security_puppet", "version_requirement": ">= 0.0.3" },
     { "name": "ripienaar/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" }
   ],

--- a/templates/refresh_facts.erb
+++ b/templates/refresh_facts.erb
@@ -1,0 +1,37 @@
+#!<%= @rubypath %>
+
+require "optparse"
+
+opt = OptionParser.new
+opt.banner = "Store Facts in a YAML file for MCollective"
+opt.separator ""
+
+opt.on("--out FILE", "-o", "Path to facts") do |v|
+  @outfile = v
+end
+
+opt.parse!
+
+abort("Please specify a file to write to") unless @outfile
+
+require "yaml"
+require "puppet"
+require "facter"
+require "tempfile"
+
+# this was copied from cfactor lib/src/ruby/ruby.cc load_puppet
+Puppet.initialize_settings
+
+unless $LOAD_PATH.include?(Puppet[:libdir])
+  $LOAD_PATH.push(Puppet[:libdir])
+end
+
+Facter.reset
+Facter.search_external([Puppet[:pluginfactdest]])
+Puppet.initialize_facts
+
+file = Tempfile.new("facter_yaml_writer")
+file.write(Facter.to_hash.to_yaml)
+file.close
+
+File.rename(file.path, @outfile)


### PR DESCRIPTION
This will now write facts in confdir/facts.yaml on both platforms, a
script is included to generate the facts.yaml server.cfg is configured
accordingly.

A Cron job or a Windows Task Scheduler job is added to keep this
updated, untested on Windows.

Additionally adds the filemgr agent and prep for release 0.0.7

Closes #15 