### PR TITLE
19: Manage packages before gems

### DIFF
--- a/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
+++ b/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
@@ -6,7 +6,7 @@
   "summary": "<%= @plugin.metadata[:description] %>",
   "source": "<%= @plugin.metadata[:url] %>",
   "dependencies": [
-    {"name": "ripienaar/mcollective", "version_requirement": ">= 0.0.9 < 2.0.0"}
+    {"name": "ripienaar/mcollective", "version_requirement": ">= 0.0.10 < 2.0.0"}
   ],
   "requirements": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ripienaar-mcollective",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "R.I.Pienaar <rip@devco.net>",
   "license": "Apache-2.0",
   "summary": "Configure the Puppet AIO MCollective",
@@ -11,7 +11,7 @@
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" },
     { "name": "puppetlabs/inifile", "version_requirement": ">= 1.5.0 < 2.0.0" },
     { "name": "ripienaar/mcollective_agent_puppet", "version_requirement": ">= 1.11.0" },
-    { "name": "ripienaar/mcollective_agent_package", "version_requirement": ">= 4.4.0" },
+    { "name": "ripienaar/mcollective_agent_package", "version_requirement": ">= 4.3.0" },
     { "name": "ripienaar/mcollective_agent_service", "version_requirement": ">= 3.1.3" },
     { "name": "ripienaar/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
     { "name": "ripienaar/mcollective_security_puppet", "version_requirement": ">= 0.0.3" },


### PR DESCRIPTION
Previous gems were installed before packages, but gems tend to need
packages like make, gcc etc, this changes the order of things.

Additionally package installation failures will now also prevent the
plugin files from being installed

Fixes #19 