### PR TITLE
21: Configure policies for the rpcutil agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,13 @@ The default applied to all modules can be set site wide:
 mcollective::policy_default: allow
 ```
 
-You can then specify a site wide policy, here I let myself access everything on all agents:
+You can then specify a site wide policy, here I let myself access everything on all agents, these
+are array merged by hiera:
 
 ```yaml
 mcollective::site_policies:
 - action: "allow"
-  callers: "cert=rip.mcollective"
+  callers: "puppet=rip.mcollective"
   actions: "*"
   facts: "*"
   classes: "*"
@@ -181,7 +182,7 @@ policies so if you specify any you have to specify all:
 mcollective_agent_puppet::policy_default: allow
 mcollective_agent_puppet::policies:
 - action: "allow"
-  callers: "cert=developer.mcollective"
+  callers: "puppet=developer.mcollective"
   actions: "*"
   facts: "environment=development"
   classes: "*"
@@ -189,6 +190,11 @@ mcollective_agent_puppet::policies:
 
 In this way plugins can check their default policy into their repo using the `.plugin.yaml` file,
 more on that below.
+
+There is one special plugin called `rpcutil` that ships with MCollective, policies for this one
+by default allow only its `ping` action across all users, you can adjust this with
+`mcollective::rpcutil_policies`.  This should be a sane default that does not leak environment
+details more than `mco ping` already allows.
 
 Plugin Packaging
 ----------------

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,6 +18,13 @@ mcollective::server_config:
   factsource: "yaml"
   plugin.yaml: "/etc/puppetlabs/mcollective/facts.yaml"
 
+mcollective::rpcutil_policies:
+  - action: "allow"
+    actions: "ping"
+    callers: "*"
+    facts: "*"
+    classes: "*"
+
 mcollective::plugin_classes:
   - "mcollective::packager"
   - "mcollective_agent_puppet"
@@ -58,6 +65,10 @@ lookup_options:
   mcollective::collectives:
     merge: "unique"
   mcollective::plugin_classes:
+    merge: "unique"
+  mcollective::site_policies:
+    merge: "unique"
+  mcollective::rpcutil_policies:
     merge: "unique"
   mcollective::client_config:
     merge:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,4 +40,18 @@ class mcollective::config {
       value   => $value
     }
   }
+
+  $policy_content = epp("mcollective/policy_file.epp", {
+    "module"         => "rpcutil",
+    "policy_default" => $mcollective::policy_default,
+    "policies"       => $mcollective::rpcutil_policies,
+    "site_policies"  => $mcollective::site_policies
+  })
+
+  file{"${mcollective::configdir}/policies/rpcutil.policy":
+    owner      => $mcollective::plugin_owner,
+    group      => $mcollective::plugin_group,
+    mode       => $mcollective::plugin_mode,
+    content    => $policy_content
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@
 # @param plugin_mode The default mode plugin files will have
 # @param policy_default When managing plugin policies this will be the default allow/deny
 # @param site_policies Policies to apply to all agents after any module specific policies
+# @param rpcutil_policies Policies to apply to the special rpcutil agent
 # @param service_ensure Ensure value for the service
 # @param service_name The mcollective service name to notify and manage
 # @param service_enable The enable value for the service
@@ -40,6 +41,7 @@ class mcollective (
   Optional[String] $plugin_mode,
   Mcollective::Policy_action $policy_default,
   Array[Mcollective::Policy] $site_policies = [],
+  Array[Mcollective::Policy] $rpcutil_policies = [],
   Enum["stopped", "running"] $service_ensure,
   String $service_name,
   Boolean $service_enable,


### PR DESCRIPTION
By default allows the ping action to be used by everyone, allows for
hiera based overrides