### PR TITLE
add an mcollective fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2016/07/11|25   |Add a `mcollective` fact with various useful information                                                 |
 |2016/07/09|21   |Allow the `rpcutil` agent policies to be managed, set sane defaults                                      |
 |2016/07/09|19   |Manages native packages before Gems to allow for compilers to be installed before native gems            |
 |2016/07/08|17   |Include the NATS.io connector                                                                            |

--- a/lib/facter/mcollective.rb
+++ b/lib/facter/mcollective.rb
@@ -1,0 +1,34 @@
+Facter.add(:mcollective) do
+  setcode do
+    begin
+      require "mcollective"
+
+      result = {
+        "version" => MCollective::VERSION,
+        "client" => {},
+        "server" => {}
+      }
+
+      ["client", "server"].each do |config|
+        configfile = "/etc/puppetlabs/mcollective/%s.cfg" % config
+        mconfig = MCollective::Config.instance
+
+        if File.readable?(configfile)
+          MCollective::PluginManager.clear
+          mconfig.set_config_defaults(configfile)
+          mconfig.loadconfig(configfile)
+
+          result[config]["libdir"] = mconfig.libdir
+          result[config]["connector"] = mconfig.connector.downcase
+          result[config]["securityprovider"] = mconfig.securityprovider.downcase
+          result[config]["collectives"] = mconfig.collectives
+          result[config]["main_collective"] = mconfig.main_collective
+        end
+      end
+
+      result
+    rescue
+      {"error" => "%s: %s" % [$!.class, $!.to_s]}
+    end
+  end
+end


### PR DESCRIPTION
Sample fact:

```
{
  version => "2.8.8",
  client => {
    libdir => [
      "/usr/libexec/mcollective",
      "/opt/puppetlabs/mcollective/plugins",
      "/usr/share/mcollective/plugins",
      "/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/stomp-1.3.3/lib",
      "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0",
      "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/x86_64-linux",
      "/opt/puppetlabs/puppet/lib/ruby/site_ruby",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.1.0",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.1.0/x86_64-linux",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby",
      "/opt/puppetlabs/puppet/lib/ruby/2.1.0",
      "/opt/puppetlabs/puppet/lib/ruby/2.1.0/x86_64-linux",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/mcollective/vendor/systemu/lib"
    ],
    connector => "nats",
    securityprovider => "puppet",
    collectives => [
      "de_collective",
      "mcollective"
    ],
    main_collective => "mcollective"
  },
  server => {
    libdir => [
      "/usr/libexec/mcollective",
      "/opt/puppetlabs/mcollective/plugins",
      "/usr/share/mcollective/plugins",
      "/opt/puppetlabs/puppet/lib/ruby/gems/2.1.0/gems/stomp-1.3.3/lib",
      "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0",
      "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0/x86_64-linux",
      "/opt/puppetlabs/puppet/lib/ruby/site_ruby",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.1.0",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/2.1.0/x86_64-linux",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby",
      "/opt/puppetlabs/puppet/lib/ruby/2.1.0",
      "/opt/puppetlabs/puppet/lib/ruby/2.1.0/x86_64-linux",
      "/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/mcollective/vendor/systemu/lib"
    ],
    connector => "nats",
    securityprovider => "puppet",
    collectives => [
      "de_collective",
      "mcollective"
    ],
    main_collective => "mcollective"
  }
}
```

Closes #25 