### PR TITLE
24: Move the audit logs to AIO standard logdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
 |2016/07/11|25   |Add a `mcollective` fact with various useful information                                                 |
+|2016/07/11|24   |Move main and audit logs into AIO standard paths                                                         |
 |2016/07/09|21   |Allow the `rpcutil` agent policies to be managed, set sane defaults                                      |
 |2016/07/09|19   |Manages native packages before Gems to allow for compilers to be installed before native gems            |
 |2016/07/08|17   |Include the NATS.io connector                                                                            |

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ Components Installed / Configured
   * [Service Agent](https://github.com/puppetlabs/mcollective-service-agent)
   * [File Manager Agent](https://github.com/puppetlabs/mcollective-filemgr-agent)
   * [Action Policy Authorization](https://github.com/puppetlabs/mcollective-actionpolicy-auth) with default secure settings
-  * Audit logs in `/var/log/mcollective-audit.log` and `C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log`
+  * Audit logs in `/var/log/puppetlabs/mcollective-audit.log` and `C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log`
   * Facts using a YAML file refreshed using Cron or Windows Scheduler
   * Configures the main `server.cfg` and `client.cfg` and service
   * Provides a mcollective plugin packager that produce AIO specific modules of mco plugins
+  * Custom `mcollective` fact exposing key client and server configuration and version
 
 Installation
 ------------

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,7 +14,7 @@ mcollective::server_config:
   rpcauthprovider: "action_policy"
   rpcaudit: 1
   rpcauditprovider: "logfile"
-  plugin.rpcaudit.logfile: "/var/log/mcollective-audit.log"
+  plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
   factsource: "yaml"
   plugin.yaml: "/etc/puppetlabs/mcollective/facts.yaml"
 

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -7,5 +7,6 @@ mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
 mcoollective::rubypath: "C:/ProgramData/PuppetLabs/puppet/bin/ruby.exe"
 
 mcollective::server_config:
+  logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log"
   plugin.rpcaudit.logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log"
   plugin.yaml: "C:/ProgramData/PuppetLabs/mcollective/etc/facts.yaml"

--- a/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
+++ b/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
@@ -99,7 +99,9 @@ module MCollective
       def copy_module_files
         @plugin.packagedata.each do |klass, data|
           data[:files].each do |file|
-            dest_dir = File.expand_path(File.join(@tmpdir, "files", "mcollective", File.dirname(file)))
+            clean_dest_file = file.gsub("./lib/mcollective", "")
+            dest_dir = File.expand_path(File.join(@tmpdir, "files", "mcollective", File.dirname(clean_dest_file)))
+
             FileUtils.mkdir_p(dest_dir) unless File.directory?(dest_dir)
             FileUtils.cp(file, dest_dir) if File.file?(file)
           end


### PR DESCRIPTION
This moves the audit log to the AIO standard logdir

Also fixes a small bug in the AIO packager that would put files of
strictly unsupported plugin types in the wrong place

Closes #24 