### PR TITLE
31: Improve client subcollective setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2016/07/12|31   |Improve client sub collective handling                                                                   |
 |2016/07/11|28   |Install the PuppetDB based discovery plugin                                                              |
 |2016/07/11|25   |Add a `mcollective` fact with various useful information                                                 |
 |2016/07/11|24   |Move main and audit logs into AIO standard paths                                                         |

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,28 +1,33 @@
 class mcollective::config {
-  $server_config = $mcollective::common_config + $mcollective::server_config
-  $client_config = $mcollective::common_config + $mcollective::client_config
-
   if $mcollective::main_collective {
     $main_collective = $mcollective::main_collective
   } else {
     $main_collective = $mcollective::collectives[-1]
   }
 
-  ["server", "client"].each |$cfg| {
-    ini_setting{"${name}_${cfg}_main_collective":
-      path    => "${mcollective::configdir}/${cfg}.cfg",
-      setting => "main_collective",
-      value   => $main_collective,
-      notify  => Class["mcollective::service"]
-    }
-
-    ini_setting{"${name}_${cfg}_collectives":
-      path    => "${mcollective::configdir}/${cfg}.cfg",
-      setting => "collectives",
-      value   => $mcollective::collectives.join(","),
-      notify  => Class["mcollective::service"]
-    }
+  if $mcollective::client_main_collective {
+    $client_main_collective = $mcollective::client_main_collective
+  } else {
+    $client_main_collective = $main_collective
   }
+
+  $client_collectives = {
+    "collectives"     => $mcollective::client_collectives.join(","),
+    "main_collective" => $client_main_collective
+  }
+
+  $server_collectives = {
+    "collectives"     => $mcollective::collectives.join(","),
+    "main_collective" => $main_collective
+  }
+
+  # The order of these are important:
+  #
+  # - common config is effectively defaults, overridable by specific server/client settings
+  # - sub collective setup is derived from the class parameters, but should be overridable by server/client ccofig
+  # - client_config and server_config has highest priority and overrules everything
+  $server_config = $mcollective::common_config + $server_collectives + $mcollective::server_config
+  $client_config = $mcollective::common_config + $client_collectives + $mcollective::client_config
 
   $server_config.each |$item, $value| {
     ini_setting{"${name}_server_${item}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,9 @@
 # @param facts_refresh_interval Minutes between fact refreshes, set to 0 to disable cron based refreshes
 # @param rubypath Path to the ruby executable
 # @param collectives A list of collectives the node belongs to
+# @param client_collectives A list of collectives the client has access to, defaults to the same as the node
 # @param main_collective The main collective to use, last in the list of `$collectives` by default
+# @param client_main_collective The main collective to use on the client, `$main_collective` by default
 # @param plugin_owner The default user who will own plugin files
 # @param plugin_group The default group who will own plugin files
 # @param plugin_mode The default mode plugin files will have
@@ -35,7 +37,9 @@ class mcollective (
   String $rubypath,
   Integer $facts_refresh_interval,
   Array[Mcollective::Collective] $collectives,
+  Array[Mcollective::Collective] $client_collectives = $collectives,
   Optional[Mcollective::Collective] $main_collective = undef,
+  Optional[Mcollective::Collective] $client_main_collective = undef,
   Optional[String] $plugin_owner,
   Optional[String] $plugin_group,
   Optional[String] $plugin_mode,


### PR DESCRIPTION
Previously client collectives were identical to server collectives, this
is no good as client workstation is often capable of doing more than the
node its on.

This adds mcollective::client_main_collective and
mcollective::client_collectives which both defaults to the main settings
since subcollectives is probably a niche feature this will work for most
but allows for specific client handling if desired

The entire collective setup can be overriden using
mcollective::server_config and mcollective::client_config if users find
that easier to use