### PR TITLE
(#37) fix path to individual plugin configs and allow purging old ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/07/28|37   |Fix file name for per plugin configs and allow purging old files                                         |
 |2016/07/26|35   |Use ripienaar/mcollective-choria instead of specific modules                                             |
 |2016/07/12|31   |Improve client sub collective handling                                                                   |
 |2016/07/11|28   |Install the PuppetDB based discovery plugin                                                              |

--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ Components Installed / Configured
 ---------------------------------
 
   * [Choria Orchestrator](https://github.com/ripienaar/mcollective-choria) Puppet Security, NATS connector, PuppetDB discovery and Application Orchastrator
-  * [Puppet Agent](https://github.com/puppetlabs/mcollective-puppet-agent)
-  * [Package Agent](https://github.com/puppetlabs/mcollective-package-agent)
-  * [Service Agent](https://github.com/puppetlabs/mcollective-service-agent)
-  * [File Manager Agent](https://github.com/puppetlabs/mcollective-filemgr-agent)
+  * [Puppet Agent](https://github.com/puppetlabs/mcollective-puppet-agent), [Package Agent](https://github.com/puppetlabs/mcollective-package-agent), [Service Agent](https://github.com/puppetlabs/mcollective-service-agent), [File Manager Agent](https://github.com/puppetlabs/mcollective-filemgr-agent)
   * [Action Policy Authorization](https://github.com/puppetlabs/mcollective-actionpolicy-auth) with default secure settings
   * Audit logs in `/var/log/puppetlabs/mcollective-audit.log` and `C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log`
   * Facts using a YAML file refreshed using Cron or Windows Scheduler

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -36,6 +36,7 @@ mcollective::plugin_classes:
 
 mcollective::server: true
 mcollective::client: false
+mcollective::purge: false
 mcollective::facts_refresh_interval: 10
 mcollective::service_name: "mcollective"
 mcollective::service_ensure: "running"

--- a/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
+++ b/files/mcollective/pluginpackager/templates/aiomodule/metadata.json.erb
@@ -6,7 +6,7 @@
   "summary": "<%= @plugin.metadata[:description] %>",
   "source": "<%= @plugin.metadata[:url] %>",
   "dependencies": [
-    {"name": "ripienaar/mcollective", "version_requirement": ">= 0.0.15 < 2.0.0"}
+    {"name": "ripienaar/mcollective", "version_requirement": ">= 0.0.16 < 2.0.0"}
   ],
   "requirements": [
     {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@
 # @param service_enable The enable value for the service
 # @param client Install client files on this node
 # @param server Install server files on this node
+# @param purge When true will remove unmanaged files from the $configdir/plugin.d, $configdir/policies and $libdir
 class mcollective (
   Array[String] $plugintypes,
   Array[String] $plugin_classes,
@@ -50,7 +51,8 @@ class mcollective (
   String $service_name,
   Boolean $service_enable,
   Boolean $client,
-  Boolean $server
+  Boolean $server,
+  Boolean $purge
 ) {
   $factspath = "${configdir}/facts.yaml"
 
@@ -61,4 +63,3 @@ class mcollective (
 
   include $plugin_classes - $plugin_classes_exclude
 }
-

--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -87,10 +87,17 @@ define mcollective::module_plugin (
   }
 
   unless $merged_conf.empty {
+    file{"${configdir}/plugin.d/${config_name}.cfg":
+      owner  => $owner,
+      group  => $group,
+      mode   => $mode,
+      ensure => $ensure
+    }
+
     $merged_conf.each |$item, $value| {
       ini_setting{"${name}-${config_name}-${item}":
         ensure  => $ensure,
-        path    => "${configdir}/plugin.d/${config_name}.conf",
+        path    => "${configdir}/plugin.d/${config_name}.cfg",
         setting => $item,
         value   => $value
       }

--- a/manifests/plugin_dirs.pp
+++ b/manifests/plugin_dirs.pp
@@ -10,10 +10,26 @@ class mcollective::plugin_dirs {
     $libdirs
   ]
 
-  file{$needed_dirs:
-    ensure => "directory",
-    owner  => $mcollective::plugin_owner,
-    group  => $mcollective::plugin_group,
-    mode   => $mcollective::plugin_mode
+  if $mcollective::purge {
+    $purge_options = {
+      source  => "puppet:///modules/mcollective/empty",
+      ignore  => ".keep",
+      purge   => true,
+      recurse => true,
+      force   => true
+    }
+  } else {
+    $purge_options = {}
+  }
+
+  file {
+    default:
+      * =>  $purge_options;
+
+    $needed_dirs:
+      ensure => "directory",
+      owner  => $mcollective::plugin_owner,
+      group  => $mcollective::plugin_group,
+      mode   => $mcollective::plugin_mode;
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ripienaar-mcollective",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "author": "R.I.Pienaar <rip@devco.net>",
   "license": "Apache-2.0",
   "summary": "Configure the Puppet AIO MCollective",


### PR DESCRIPTION
First this fixes an important bug where per plugin config in plugin.d
was written to an incorrectly named file, so they were just not working

To clean up this mess a new property $mcollective::purge has been added
that will nuke unmanaged files in policies, plugin.d and the main libdir
where the module plugin helper installs its files

Closes #37 