### PR TITLE
(#47) Run fact refresher only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/08/11|47   |When refreshing facts with cron, do not run facts writer on every Puppet run                             |
+|2017/08/09|43   |Correctly handle temp file renaming in cases where /tmp and /etc do not share a partition (Daniel Sung)  |
 |2017/08/01|     |Release 0.0.17                                                                                           |
 |2017/08/01|41   |Handle cases of both client=false and server=false gracefully in module installer                        |
 |2017/08/01|41   |Uniquely tag agent ruby files to facilitate agent discovery                                              |

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -17,16 +17,19 @@ class mcollective::facts (
     content => template("mcollective/refresh_facts.erb"),
   }
 
+  if $refresh_interval > 0 and $server {
+    $cron_ensure = "present"
+    $creates = $factspath
+  } else {
+    $cron_ensure = "absent"
+    $creates = undef # always run via puppet when opted out of cron option
+  }
+
   if $server {
     exec{"mcollective_facts_yaml_refresh":
       command => "${scriptpath} -o ${factspath}",
+      creates => $creates
     }
-  }
-
-  if $refresh_interval > 0 and $server {
-    $cron_ensure = "present"
-  } else {
-    $cron_ensure = "absent"
   }
 
   if $facts["os"]["family"] == "windows" {


### PR DESCRIPTION
Previously the facts refresher would run during every Puppet run, nice
to have fresh facts but can become annoying.

This updates the code to use creates to check if the facts file exist
already and do not run the script.

When facts_refresh_interval = 0 the script is always run by Puppet since
there will be no cron to do it

Closes #47 