### PR TITLE
(#50) configure the path to puppet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
-|2017/08/11|     |Release 0.0.18                                                                                           |
-|2017/08/11|47   |When refreshing facts with cron, do not run facts writer on every Puppet run                             |
-|2017/08/09|43   |Correctly handle temp file renaming in cases where /tmp and /etc do not share a partition (Daniel Sung)  |
-|2017/08/01|     |Release 0.0.17                                                                                           |
-|2017/08/01|41   |Handle cases of both client=false and server=false gracefully in module installer                        |
-|2017/08/01|41   |Uniquely tag agent ruby files to facilitate agent discovery                                              |
-|2017/07/31|39   |Install action policies only on nodes with `$server` set                                                 |
-|2017/07/28|37   |Fix file name for per plugin configs and allow purging old files                                         |
+|2016/08/13|50   |Configure path to the puppet executable                                                                  |
+|2016/08/11|     |Release 0.0.18                                                                                           |
+|2016/08/11|47   |When refreshing facts with cron, do not run facts writer on every Puppet run                             |
+|2016/08/09|43   |Correctly handle temp file renaming in cases where /tmp and /etc do not share a partition (Daniel Sung)  |
+|2016/08/01|     |Release 0.0.17                                                                                           |
+|2016/08/01|41   |Handle cases of both client=false and server=false gracefully in module installer                        |
+|2016/08/01|41   |Uniquely tag agent ruby files to facilitate agent discovery                                              |
+|2016/07/31|39   |Install action policies only on nodes with `$server` set                                                 |
+|2016/07/28|37   |Fix file name for per plugin configs and allow purging old files                                         |
 |2016/07/26|35   |Use ripienaar/mcollective-choria instead of specific modules                                             |
 |2016/07/12|31   |Improve client sub collective handling                                                                   |
 |2016/07/11|28   |Install the PuppetDB based discovery plugin                                                              |

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -34,6 +34,10 @@ mcollective::plugin_classes:
   - "mcollective_agent_filemgr"
   - "mcollective_util_actionpolicy"
 
+mcollective_agent_puppet::server_config:
+  "command": "/opt/puppetlabs/bin/puppet agent"
+  "signal_daemon": false
+
 mcollective::server: true
 mcollective::client: false
 mcollective::purge: false

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -10,3 +10,8 @@ mcollective::server_config:
   logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log"
   plugin.rpcaudit.logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log"
   plugin.yaml: "C:/ProgramData/PuppetLabs/mcollective/etc/facts.yaml"
+
+mcollective_agent_puppet::server_config:
+  "command": "C:/Program Files/Puppet Labs/Puppet/bin/puppet agent"
+  "signal_daemon": false
+  "windows_service": "puppet"


### PR DESCRIPTION
Without this for people who do not put the puppet files in their path or
make symlinks the puppet-agent cant find the command to kick off new
runs