### PR TITLE
(#52, #53, #54, #55) resolve various windows issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
-|2017/08/11|     |Release 0.0.18                                                                                           |
-|2017/08/11|47   |When refreshing facts with cron, do not run facts writer on every Puppet run                             |
-|2017/08/09|43   |Correctly handle temp file renaming in cases where /tmp and /etc do not share a partition (Daniel Sung)  |
-|2017/08/01|     |Release 0.0.17                                                                                           |
-|2017/08/01|41   |Handle cases of both client=false and server=false gracefully in module installer                        |
-|2017/08/01|41   |Uniquely tag agent ruby files to facilitate agent discovery                                              |
-|2017/07/31|39   |Install action policies only on nodes with `$server` set                                                 |
-|2017/07/28|37   |Fix file name for per plugin configs and allow purging old files                                         |
+|2016/08/13|55   |Use the correct lib dirs for facter on windows                                                           |
+|2016/08/13|54   |Correct typo on hiera data for windows                                                                   |
+|2016/08/13|53   |Correct path to the ruby executable and fix quoting                                                      |
+|2016/08/13|52   |Correct data types on mcollective::facts for windows support                                             |
+|2016/08/11|     |Release 0.0.18                                                                                           |
+|2016/08/11|47   |When refreshing facts with cron, do not run facts writer on every Puppet run                             |
+|2016/08/09|43   |Correctly handle temp file renaming in cases where /tmp and /etc do not share a partition (Daniel Sung)  |
+|2016/08/01|     |Release 0.0.17                                                                                           |
+|2016/08/01|41   |Handle cases of both client=false and server=false gracefully in module installer                        |
+|2016/08/01|41   |Uniquely tag agent ruby files to facilitate agent discovery                                              |
+|2016/07/31|39   |Install action policies only on nodes with `$server` set                                                 |
+|2016/07/28|37   |Fix file name for per plugin configs and allow purging old files                                         |
 |2016/07/26|35   |Use ripienaar/mcollective-choria instead of specific modules                                             |
 |2016/07/12|31   |Improve client sub collective handling                                                                   |
 |2016/07/11|28   |Install the PuppetDB based discovery plugin                                                              |

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -4,7 +4,7 @@ mcollective::plugin_mode: ~
 
 mcollective::libdir: "C:/ProgramData/PuppetLabs/mcollective/plugins"
 mcollective::configdir: "C:/ProgramData/PuppetLabs/mcollective/etc"
-mcoollective::rubypath: "C:/ProgramData/PuppetLabs/puppet/bin/ruby.exe"
+mcollective::rubypath: 'C:\Program Files\Puppet Labs\Puppet\sys\ruby\bin\ruby.exe'
 
 mcollective::server_config:
   logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log"

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -4,8 +4,8 @@ class mcollective::facts (
   String $configdir = $mcollective::configdir,
   String $factspath = $mcollective::factspath,
   Integer $refresh_interval = $mcollective::facts_refresh_interval,
-  String $owner = $mcollective::plugin_owner,
-  String $group = $mcollective::plugin_group,
+  Optional[String] $owner = $mcollective::plugin_owner,
+  Optional[String] $group = $mcollective::plugin_group,
   Boolean $server = $mcollective::server
 ) {
   $scriptpath = "${libdir}/refresh_facts.rb"
@@ -27,7 +27,7 @@ class mcollective::facts (
 
   if $server {
     exec{"mcollective_facts_yaml_refresh":
-      command => "${scriptpath} -o ${factspath}",
+      command => "\"${rubypath}\" \"${scriptpath}\" -o \"${factspath}\"",
       creates => $creates
     }
   }
@@ -35,8 +35,8 @@ class mcollective::facts (
   if $facts["os"]["family"] == "windows" {
     scheduled_task{"mcollective_facts_yaml_refresh":
       ensure               => $cron_ensure,
-      command              => $scriptpath,
-      arguments            => "-o ${factspath}",
+      command              => $rubypath,
+      arguments            => "'${scriptpath}' -o '${factspath}'",
       trigger              => {
         "schedule"         => "daily",
         "start_time"       => "00:00",
@@ -46,7 +46,7 @@ class mcollective::facts (
   } else {
     cron{"mcollective_facts_yaml_refresh":
       ensure  => $cron_ensure,
-      command => "${scriptpath} -o ${factspath}",
+      command => "'${rubypath}' '${scriptpath}' -o '${factspath}'",
       minute  => "*/${refresh_interval}"
     }
   }

--- a/templates/refresh_facts.erb
+++ b/templates/refresh_facts.erb
@@ -15,6 +15,12 @@ opt.parse!
 
 abort("Please specify a file to write to") unless @outfile
 
+require "rubygems"
+
+if Gem.win_platform?
+  $: << "C:/Program Files/Puppet Labs/Puppet/facter/lib"
+end
+
 require "yaml"
 require "puppet"
 require "facter"


### PR DESCRIPTION
Facts was failing because the mcollective::facts class expected a
group/owner but the mcollective class itself has them optional - the
optional is correct because on windows those are undef (#52)

The ruby path was wrong and there were various annoying quoting bad
things with windows nodes and the puppet docs are wrong (#53)

There was also a typo in the hiera data (#54)

Windows facter lib is not in vendor directory like any other sane ruby
code instead its in its own lib dir, this adds that libdir to $: on
windows (#55)

Closes #55, #54, #53, #52 