### PR TITLE
(#59) use a uniq facts source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2016/08/27|59   |Use a custom fact source - `generated-facts.yaml` - to improve bootstrapping                             |
 |2016/08/27|60   |Configure the classes file according to AIO paths                                                        |
 |2016/08/13|     |Release 0.0.19                                                                                           |
 |2016/08/13|57   |Configure libdirs on windows and rework libdir calculations a bit towards specifically setting libdir    |

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -17,7 +17,7 @@ mcollective::server_config:
   rpcauditprovider: "logfile"
   plugin.rpcaudit.logfile: "/var/log/puppetlabs/mcollective-audit.log"
   factsource: "yaml"
-  plugin.yaml: "/etc/puppetlabs/mcollective/facts.yaml"
+  plugin.yaml: "/etc/puppetlabs/mcollective/generated-facts.yaml"
 
 mcollective::rpcutil_policies:
   - action: "allow"

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -13,4 +13,4 @@ mcollective::server_config:
   classesfile: "C:/ProgramData/PuppetLabs/puppet/cache/state/classes.txt"
   logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective.log"
   plugin.rpcaudit.logfile: "C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log"
-  plugin.yaml: "C:/ProgramData/PuppetLabs/mcollective/etc/facts.yaml"
+  plugin.yaml: "C:/ProgramData/PuppetLabs/mcollective/etc/generated-facts.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@ class mcollective (
   Boolean $server,
   Boolean $purge
 ) {
-  $factspath = "${configdir}/facts.yaml"
+  $factspath = "${configdir}/generated-facts.yaml"
 
   include mcollective::plugin_dirs
   include mcollective::config


### PR DESCRIPTION
We now only run the exec that generates facts when the file does not
exist already unfortunately by default the file already exist so it is
never run leading to a 10 minute delay for facts

So now we use generated-facts.yaml instead to avoid the bootstrapping
problem