### PR TITLE
(#63) deep merge mcollective::common_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2016/08/27|63   |Deep merge mcollective::common_config                                                                    |
 |2016/08/27|59   |Use a custom fact source - `generated-facts.yaml` - to improve bootstrapping                             |
 |2016/08/27|60   |Configure the classes file according to AIO paths                                                        |
 |2016/08/13|     |Release 0.0.19                                                                                           |

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -77,3 +77,6 @@ lookup_options:
   mcollective::server_config:
     merge:
       strategy: "deep"
+  mcollective::common_config:
+    merge:
+      strategy: "deep"


### PR DESCRIPTION
server_config and client_cofig are both deep merged but common_config
was left out by accident

Close #63 