### PR TITLE
fix potential match of multiple rb files under agent directory

### DIFF
--- a/manifests/module_plugin.pp
+++ b/manifests/module_plugin.pp
@@ -121,7 +121,7 @@ define mcollective::module_plugin (
     }
 
     $merged_files.each |$file| {
-      if $file =~ /agent\/(.+).rb/ {
+      if $file =~ /agent\/([^\/]+).rb/ {
         $f_tag = "mcollective_agent_${1}_server"
       } else {
         $f_tag = undef


### PR DESCRIPTION
I came across this issue when trying to deploy the super nasty mcollective shell agent (that's bad I know). You can test it against m4ce/mcollective_agent_shell module on the forge.