### PR TITLE
(#69) adjust dependencies for librarian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/01/03|69   |Adjust dependencies so that librarian will install the module                                            |
 |2016/11/10|     |Release 0.0.21                                                                                           |
 |2016/11/09|67   |Improve handling of agents like the shell one with a invalid plugin layout                               |
 |2016/08/27|     |Release 0.0.20                                                                                           |

--- a/README.md
+++ b/README.md
@@ -1,41 +1,16 @@
 Manage an AIO Installation of The Marionette Collective
 =======================================================
 
-This module manages an already installed Puppet AIO based MCollective.
+This module manages a Puppet AIO based MCollective.
 
 It makes default decisions that are compatible with AIO and tries to get as
 close to working out of the box with no complex config or decision making needed
 on the side of the user.
 
-Towards this it makes many of decisions related to security plugin, middleware,
-facts etc and finally installs a number of plugins out of the box.
+The module can be used standalone but it's designed to work with Choria - a companion
+suite of plugins that makes a AIO based MCollective easy to install and use.
 
-The goal is that this Just Works while being secure by default.  It sets up strong
-CA verified TLS connections to your middleware and sets up a similar CA verified
-security plugin for MCollective.
-
-It configures the full AAA (Authentication, Authorization and Auditing) that MCollective
-supports and it all works out of the box.
-
-Users do not need per-user configuration files and it integrates well and naturally
-into the Puppet eco system.
-
-Components Installed / Configured
----------------------------------
-
-  * [Choria Orchestrator](https://github.com/ripienaar/mcollective-choria) Puppet Security, NATS connector, PuppetDB discovery and Application Orchastrator
-  * [Puppet Agent](https://github.com/puppetlabs/mcollective-puppet-agent), [Package Agent](https://github.com/puppetlabs/mcollective-package-agent), [Service Agent](https://github.com/puppetlabs/mcollective-service-agent), [File Manager Agent](https://github.com/puppetlabs/mcollective-filemgr-agent)
-  * [Action Policy Authorization](https://github.com/puppetlabs/mcollective-actionpolicy-auth) with default secure settings
-  * Audit logs in `/var/log/puppetlabs/mcollective-audit.log` and `C:/ProgramData/PuppetLabs/mcollective/var/log/mcollective-audit.log`
-  * Facts using a YAML file refreshed using Cron or Windows Scheduler
-  * Configures the main `server.cfg` and `client.cfg` and service
-  * Provides an MCollective plugin packager that produce AIO specific modules of mco plugins
-  * Custom `mcollective` fact exposing key client and server configuration and version
-
-Installation
-------------
-
-Follow the guide at the [Choria Wiki](https://github.com/ripienaar/mcollective-choria/wiki)
+Follow the guide at the [Choria Website](http://choria.io) for installation details
 
 Facts
 -----

--- a/metadata.json
+++ b/metadata.json
@@ -9,13 +9,7 @@
   "issues_url": "https://github.com/ripienaar/puppet-mcollective/issues",
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.12.0 < 5.0.0" },
-    { "name": "puppetlabs/inifile", "version_requirement": ">= 1.5.0 < 2.0.0" },
-    { "name": "ripienaar/mcollective_agent_puppet", "version_requirement": ">= 1.11.0" },
-    { "name": "ripienaar/mcollective_agent_package", "version_requirement": ">= 4.3.0" },
-    { "name": "ripienaar/mcollective_agent_service", "version_requirement": ">= 3.1.3" },
-    { "name": "ripienaar/mcollective_agent_filemgr", "version_requirement": ">= 1.1.0" },
-    { "name": "ripienaar/mcollective_util_actionpolicy", "version_requirement": ">= 2.1.0" },
-    { "name": "ripienaar/mcollective_choria", "version_requirement": ">= 0.0.1" }
+    { "name": "puppetlabs/inifile", "version_requirement": ">= 1.5.0 < 2.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
This module has a bunch of choria dependencies on it which I put there
so people get a nice simple install process - just install the
mcollective module and choria comes with.

But in turn the choria modules need this module as a dependency so they
can use the plugin installer.

puppet module install does not complain about this circular dependency
but librarian does so this makes the mcollective module be standalone
and the choria one will bring all its dependencies which is probably the
more correct design anyway