### PR TITLE
(#78) ensure module names are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/01/29|78   |Convert `-` in module names to `_`                                                                       |
 |2017/01/13|     |Release 0.0.23                                                                                           |
 |2017/01/13|74   |Resolve issues with Windows paths in fact and libdir                                                     |
 |2017/01/03|     |Release 0.0.22                                                                                           |

--- a/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
+++ b/files/mcollective/pluginpackager/aiomodulepackage_packager.rb
@@ -45,7 +45,10 @@ module MCollective
         end
       end
       def module_name
-        "mcollective_%s_%s" % [@plugin.plugintype.downcase, @plugin.metadata[:name].downcase]
+        "mcollective_%s_%s" % [
+          @plugin.plugintype.downcase,
+          @plugin.metadata[:name].downcase.gsub("-", "_")
+        ]
       end
 
       def module_file_name


### PR DESCRIPTION
MCollective internal packaging turns some special characters into "-"
in package names.  This is not valid in module so we have to turn them
into underscores