### PR TITLE
(#81) Ensure fact generation passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue|Description                                                                                              |
 |----------|-----|---------------------------------------------------------------------------------------------------------|
+|2017/02/01|81   |Run the fact generator after the service is up                                                           |
 |2017/01/29|78   |Convert `-` in module names to `_`                                                                       |
 |2017/01/13|     |Release 0.0.23                                                                                           |
 |2017/01/13|74   |Resolve issues with Windows paths in fact and libdir                                                     |

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -28,7 +28,8 @@ class mcollective::facts (
   if $server {
     exec{"mcollective_facts_yaml_refresh":
       command => "\"${rubypath}\" \"${scriptpath}\" -o \"${factspath}\"",
-      creates => $creates
+      creates => $creates,
+      require => Class["mcollective::service"]
     }
   }
 


### PR DESCRIPTION
Facts generator was run too early and would fail since the libraries
werent there.  This ensures it runs after the service

Closes #81 